### PR TITLE
Add the ability to disable the colored output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Configuration for the Erlang logger.
 ```sh
 gleam add logging
 ```
+
 ```gleam
 import logging.{Info}
 
@@ -19,5 +20,12 @@ pub fn main() {
   logging.log(Info, "Hello, Joe!")
 }
 ```
+
+## Disabling the colored output
+
+When using some logger services, colored output can be superfluous, because
+they're not processed at all, and appears as real characters. You can set
+the `NO_COLOR` to `true` or `True` in your environment to disable the colored
+output from the logger.
 
 Further documentation can be found at <https://hexdocs.pm/logging>.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pub fn main() {
 
 When using some logger services, colored output can be superfluous, because
 they're not processed at all, and appears as real characters. You can set
-the `NO_COLOR` to any string that _is not_ `"false"` in your environment to
-disable the colored output from the logger.
+the `NO_COLOR` to any string that _is not_ `"false"` or the empty string in your
+environment to disable the colored output from the logger.
 
 Further documentation can be found at <https://hexdocs.pm/logging>.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pub fn main() {
 
 When using some logger services, colored output can be superfluous, because
 they're not processed at all, and appears as real characters. You can set
-the `NO_COLOR` to `true` or `True` in your environment to disable the colored
-output from the logger.
+the `NO_COLOR` to any string that _is not_ `"false"` in your environment to
+disable the colored output from the logger.
 
 Further documentation can be found at <https://hexdocs.pm/logging>.

--- a/src/logging_ffi.erl
+++ b/src/logging_ffi.erl
@@ -20,6 +20,7 @@ is_colored_output() ->
     case os:getenv("NO_COLOR") of
         false -> true;
         "false" -> true;
+        "" -> true;
         _ -> false
     end.
 

--- a/src/logging_ffi.erl
+++ b/src/logging_ffi.erl
@@ -23,16 +23,21 @@ format(#{level := Level, msg := Msg, meta := _Meta}) ->
     [format_level(Level), format_msg(Msg), $\n].
 
 format_level(Level) ->
-    case Level of
-        emergency -> "\x1b[1;41mEMRG\x1b[0m";
-        alert -> "\x1b[1;41mALRT\x1b[0m";
-        critical -> "\x1b[1;41mCRIT\x1b[0m";
-        error -> "\x1b[1;31mEROR\x1b[0m";
-        warning -> "\x1b[1;33mWARN\x1b[0m";
-        notice -> "\x1b[1;32mNTCE\x1b[0m";
-        info -> "\x1b[1;34mINFO\x1b[0m";
-        debug -> "\x1b[1;36mDEBG\x1b[0m"
-    end.
+  {Msg, StartColor, EndColor} = case Level of
+      emergency -> {"EMRG", "\x1b[1;41m", "\x1b[0m"};
+      alert -> {"ALRT", "\x1b[1;41m", "\x1b[0m"};
+      critical -> {"CRIT", "\x1b[1;41m", "\x1b[0m"};
+      error -> {"EROR", "\x1b[1;31m", "\x1b[0m"};
+      warning -> {"WARN", "\x1b[1;33m", "\x1b[0m"};
+      notice -> {"NTCE", "\x1b[1;32m", "\x1b[0m"};
+      info -> {"INFO", "\x1b[1;34m", "\x1b[0m"};
+      debug -> {"DEBG", "\x1b[1;36m", "\x1b[0m"}
+  end,
+  case os:getenv("NO_COLOR") of
+    "true" -> Msg;
+    "True" -> Msg;
+    _ -> lists:concat([StartColor, Msg, EndColor])
+  end.
 
 format_msg(Report0) ->
     case Report0 of
@@ -53,11 +58,11 @@ format_kv(Pairs) ->
     case Pairs of
         [] -> [];
         [{K, V} | Rest] when is_atom(K) -> [
-            $\s, erlang:atom_to_binary(K), $=, gleam@string:inspect(V) 
+            $\s, erlang:atom_to_binary(K), $=, gleam@string:inspect(V)
             | format_kv(Rest)
         ];
         [{K, V} | Rest]  -> [
-            $\s, gleam@string:inspect(K), $=, gleam@string:inspect(V) 
+            $\s, gleam@string:inspect(K), $=, gleam@string:inspect(V)
             | format_kv(Rest)
         ];
         Other -> gleam@string:inspect(Other)

--- a/src/logging_ffi.erl
+++ b/src/logging_ffi.erl
@@ -12,32 +12,39 @@ configure() ->
         metadata => #{}
     }),
     logger:update_handler_config(default, #{
-        formatter => {logging_ffi, []}
+        formatter => {logging_ffi, #{colored => is_colored_output()}}
     }),
     nil.
 
-format(Event, _Config) ->
-    format(Event).
+is_colored_output() ->
+    case os:getenv("NO_COLOR") of
+        false -> true;
+        "false" -> true;
+        _ -> false
+    end.
 
-format(#{level := Level, msg := Msg, meta := _Meta}) ->
-    [format_level(Level), format_msg(Msg), $\n].
+format(#{level := Level, msg := Msg, meta := _Meta}, Config) ->
+    [format_level(Level, Config), format_msg(Msg), $\n].
 
-format_level(Level) ->
-  {Msg, StartColor, EndColor} = case Level of
-      emergency -> {"EMRG", "\x1b[1;41m", "\x1b[0m"};
-      alert -> {"ALRT", "\x1b[1;41m", "\x1b[0m"};
-      critical -> {"CRIT", "\x1b[1;41m", "\x1b[0m"};
-      error -> {"EROR", "\x1b[1;31m", "\x1b[0m"};
-      warning -> {"WARN", "\x1b[1;33m", "\x1b[0m"};
-      notice -> {"NTCE", "\x1b[1;32m", "\x1b[0m"};
-      info -> {"INFO", "\x1b[1;34m", "\x1b[0m"};
-      debug -> {"DEBG", "\x1b[1;36m", "\x1b[0m"}
-  end,
-  case os:getenv("NO_COLOR") of
-    "true" -> Msg;
-    "True" -> Msg;
-    _ -> lists:concat([StartColor, Msg, EndColor])
-  end.
+format_level(Level, #{colored := Colored}) ->
+    case Level of
+        emergency when Colored -> "\x1b[1;41mEMRG\x1b[0m";
+        alert when Colored -> "\x1b[1;41mALRT\x1b[0m";
+        critical when Colored -> "\x1b[1;41mCRIT\x1b[0m";
+        error when Colored -> "\x1b[1;31mEROR\x1b[0m";
+        warning when Colored -> "\x1b[1;33mWARN\x1b[0m";
+        notice when Colored -> "\x1b[1;32mNTCE\x1b[0m";
+        info when Colored -> "\x1b[1;34mINFO\x1b[0m";
+        debug when Colored -> "\x1b[1;36mDEBG\x1b[0m";
+        emergency -> "EMRG";
+        alert -> "ALRT";
+        critical -> "CRIT";
+        error -> "EROR";
+        warning -> "WARN";
+        notice -> "NTCE";
+        info -> "INFO";
+        debug -> "DEBG"
+    end.
 
 format_msg(Report0) ->
     case Report0 of


### PR DESCRIPTION
Hi!
Here's a proposal directly, instead of opening an issue. 🙂

In some logger services, the colours characters are not taken into account. As such, the logger should be able to not display any colour when logging.
Because it's most often happening on production server, and instead of having to modify the code by hand, an environment variable can be set, according to switch on or off the logger just on environment.

Feel free to tell me what you think about this, everything is opened to discussion of course.