### PR TITLE
Add logger to extra applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Specifies the `logger` application to start as an `extra_application`
+
 ## v1.3.0 - 2024-07-15
 
 - The `NO_COLOUR` or `NO_COLOR` environment variable can now be used to disable

--- a/gleam.toml
+++ b/gleam.toml
@@ -8,6 +8,9 @@ links = [
   { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
 ]
 
+[erlang]
+extra_applications = ["logger"]
+
 [dependencies]
 gleam_stdlib = "~> 0.34 or ~> 1.0"
 


### PR DESCRIPTION
There doesn't seem to be any issue with _not_ including this, but it's probably the more "correct" approach.